### PR TITLE
Async generators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/withoutboats/propane"
 documentation = "https://docs.rs/propane"
 keywords = ["iterators", "generators"]
 
+[dependencies]
+futures-core = "0.3.5"
+
 [dependencies.propane-macros]
 path = "./propane-macros"
 version = "0.1.0"

--- a/propane-macros/src/lib.rs
+++ b/propane-macros/src/lib.rs
@@ -8,7 +8,7 @@ use syn::fold::Fold;
 #[proc_macro_attribute]
 pub fn generator(_: TokenStream, input: TokenStream) -> TokenStream {
     if let Ok(item_fn) = syn::parse(input) {
-        let item_fn = Generator { outer_fn: true, lifetimes: vec![] }.fold_item_fn(item_fn);
+        let item_fn = Generator { outer_fn: true, is_async: false, lifetimes: vec![] }.fold_item_fn(item_fn);
         quote::quote!(#item_fn).into()
     } else {
         panic!("#[generator] atribute can only be applied to functions");
@@ -17,6 +17,7 @@ pub fn generator(_: TokenStream, input: TokenStream) -> TokenStream {
 
 struct Generator {
     outer_fn: bool,
+    is_async: bool,
     lifetimes: Vec<syn::Lifetime>,
 }
 
@@ -26,13 +27,16 @@ impl Fold for Generator {
 
         let inputs = elision::unelide_lifetimes(&mut i.sig.generics.params, i.sig.inputs);
         self.lifetimes = i.sig.generics.lifetimes().map(|l| l.lifetime.clone()).collect();
+
+        self.is_async = i.sig.asyncness.is_some();
+
         let output = self.fold_return_type(i.sig.output);
-        let sig = syn::Signature { output, inputs, ..i.sig };
+        let sig = syn::Signature { output, inputs, asyncness: None, ..i.sig };
 
         self.outer_fn = false;
 
         let inner = self.fold_block(*i.block);
-        let block = Box::new(make_fn_block(&inner));
+        let block = Box::new(make_fn_block(&inner, self.is_async));
 
         syn::ItemFn { sig, block, ..i }
     }
@@ -41,38 +45,73 @@ impl Fold for Generator {
         use syn::{ReturnType, Token};
         use proc_macro2::Span;
         if !self.outer_fn { return i; }
+        
         let (arrow, ret) = match i {
             ReturnType::Default => (Token![->](Span::call_site()), syn::parse_str("()").unwrap()),
             ReturnType::Type(arrow, ty) => (arrow, *ty),
         };
         let lifetimes = std::mem::replace(&mut self.lifetimes, vec![]);
-        let ret = syn::parse2(quote::quote!(
-                (impl Iterator<Item = #ret> #(+ #lifetimes )*)
-        )).unwrap();
+
+        let ret = if self.is_async {
+            syn::parse2(quote::quote!((impl propane::__internal::Stream<Item = #ret> #(+ #lifetimes )*))).unwrap()
+        } else {
+            syn::parse2(quote::quote!((impl Iterator<Item = #ret> #(+ #lifetimes )*))).unwrap()
+        };
         ReturnType::Type(arrow, Box::new(ret))
     }
 
     fn fold_expr(&mut self, i: syn::Expr) -> syn::Expr {
-        if let syn::Expr::Try(syn::ExprTry { expr, .. }) = i {
-            syn::parse2(quote::quote!(propane::gen_try!(#expr))).unwrap()
-        } else {
-            syn::fold::fold_expr(self, i)
+        match i {
+            // Stream modifiers
+            syn::Expr::Try(syn::ExprTry { expr, .. }) if self.is_async      => {
+                syn::parse2(quote::quote!(propane::async_gen_try!(#expr))).unwrap()
+            }
+            syn::Expr::Yield(syn::ExprYield { expr, .. }) if self.is_async  => {
+                syn::parse2(quote::quote!(propane::async_gen_yield!(#expr))).unwrap()
+            }
+            syn::Expr::Await(syn::ExprAwait { base: expr, ..}) if self.is_async   => {
+                syn::parse2(quote::quote!(propane::async_gen_await!(#expr, __propane_stream_ctx))).unwrap()
+            }
+
+            // Iterator modifiers
+            syn::Expr::Try(syn::ExprTry { expr, .. })                       => {
+                syn::parse2(quote::quote!(propane::gen_try!(#expr))).unwrap()
+            }
+
+            // Everything else
+            _   => syn::fold::fold_expr(self, i)
         }
     }
 }
 
-fn make_fn_block(inner: &syn::Block) -> syn::Block {
-    syn::parse2(quote::quote! {{
-        let __ret = || {
-            #inner;
-            #[allow(unreachable_code)]
-            {
-                return;
-                yield panic!();
-            }
-        };
+fn make_fn_block(inner: &syn::Block, is_async: bool) -> syn::Block {
+    if !is_async {
+        syn::parse2(quote::quote! {{
+            let __ret = || {
+                #inner;
+                #[allow(unreachable_code)]
+                {
+                    return;
+                    yield panic!();
+                }
+            };
 
-        #[allow(unreachable_code)]
-        propane::__internal::GenIter(__ret)
-    }}).unwrap()
+            #[allow(unreachable_code)]
+            propane::__internal::GenIter(__ret)
+        }}).unwrap()
+    } else {
+        syn::parse2(quote::quote! {{
+            let __ret = static |mut __propane_stream_ctx| {
+                #inner;
+                #[allow(unreachable_code)]
+                {
+                    return;
+                    yield panic!();
+                }
+            };
+
+            #[allow(unreachable_code)]
+            unsafe { propane::__internal::GenStream::new(__ret) }
+        }}).unwrap()
+    }
 }

--- a/propane-macros/src/lib.rs
+++ b/propane-macros/src/lib.rs
@@ -64,17 +64,24 @@ impl Fold for Generator {
         match i {
             // Stream modifiers
             syn::Expr::Try(syn::ExprTry { expr, .. }) if self.is_async      => {
+                let expr = self.fold_expr(*expr);
                 syn::parse2(quote::quote!(propane::async_gen_try!(#expr))).unwrap()
             }
-            syn::Expr::Yield(syn::ExprYield { expr, .. }) if self.is_async  => {
+            syn::Expr::Yield(syn::ExprYield { expr: Some(expr), .. }) if self.is_async  => {
+                let expr = self.fold_expr(*expr);
                 syn::parse2(quote::quote!(propane::async_gen_yield!(#expr))).unwrap()
             }
+            syn::Expr::Yield(syn::ExprYield { expr: None, .. }) if self.is_async  => {
+                syn::parse2(quote::quote!(propane::async_gen_yield!(()))).unwrap()
+            }
             syn::Expr::Await(syn::ExprAwait { base: expr, ..}) if self.is_async   => {
+                let expr = self.fold_expr(*expr);
                 syn::parse2(quote::quote!(propane::async_gen_await!(#expr, __propane_stream_ctx))).unwrap()
             }
 
             // Iterator modifiers
             syn::Expr::Try(syn::ExprTry { expr, .. })                       => {
+                let expr = self.fold_expr(*expr);
                 syn::parse2(quote::quote!(propane::gen_try!(#expr))).unwrap()
             }
 

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,0 +1,16 @@
+#![feature(generators, generator_trait, try_trait)]
+
+use std::future::Future;
+
+#[propane::generator]
+async fn foo<F: Future>(fut: F) -> i32 {
+    fut.await;
+    yield 0i32;
+}
+
+#[propane::generator]
+async fn stream<T, F: Future<Output = T>>(futures: Vec<F>) -> T {
+    for future in futures {
+        yield future.await;
+    }
+}


### PR DESCRIPTION
Closes #3.

Async generators can be implemented by applying the generator attribute to an async fn. They return a `futures_core::Stream` of yielded items, instead of an Iterator, and `await` works correctly inside of their bodies.

Example:

```rust
#![feature(generators, generator_trait, try_trait)]

#[propane::generator]
async fn stream<T, F: Future<Output = T>>(futures: Vec<F>) -> T {
    for future in futures {
        yield future.await;
    }
}
```

Would benefit from someone trying to write some real code and see if it works!