### PR TITLE
Fehler integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,12 @@ futures-core = "0.3.5"
 path = "./propane-macros"
 version = "0.1.0"
 
+[dependencies.fehler-crate]
+version = "1.0.0"
+optional = true
+package = "fehler"
+
+[features]
+fehler = ["fehler-crate", "propane-macros/fehler"]
+
 [workspace]

--- a/propane-macros/Cargo.toml
+++ b/propane-macros/Cargo.toml
@@ -15,5 +15,8 @@ proc-macro2 = "1.0.19"
 version = "1.0.35"
 features = ["fold", "full", "parsing"]
 
+[features]
+fehler = []
+
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,9 @@ pub mod __internal {
 
     pub use futures_core::Stream;
 
+    #[cfg(fehler)]
+    pub use fehler_crate as fehler;
+
     pub struct GenIter<G>(pub G);
 
     impl<G: Generator<Return = ()> + Unpin> Iterator for GenIter<G> {


### PR DESCRIPTION
Takes advantage of fehler's propane integration to make propane
generators Ok-wrapping.

Syntax:

```rust
use std::future::Future;
use std::io;

#[propane::generator(throws io::Error)]
async fn foo<T: Future<Output = io::Result<i32>>>(futures: Vec<T>) -> i32 {
    let mut n = 0;
    for x in futures {
       yield x.await?;

       yield n;
       n += 1;
    }
}
```